### PR TITLE
feat: emit ReactableInstrument target lifecycle events in every build

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ dependencies: [
 
 ### 🔬 Debugging
 - [`ReactableInstrument` (Cycle Performance)](#-debugging--reactableinstrument)
+- [Target Lifecycle Events](#-target-lifecycle-events)
+- [Instrumentation Cost](#-instrumentation-cost)
 
 ### 🔧 Features
 - [`ObservableEvent` (Parent-Child Communication)](#observableevent-parent-child-communication)
@@ -563,8 +565,8 @@ extension MyFactory: DependencyInjectable {
 ## 🔬 Debugging — `ReactableInstrument`
 
 `ReactableInstrument` measures every stage of the Reactable cycle and warns when one of them takes
-too long. It exists only in **DEBUG** builds — the file and every call site inside `Reactable` are
-removed by `#if DEBUG`, so a release build carries none of it.
+too long in **DEBUG** builds. It can also emit selected stage lifecycle events in all build
+configurations through a target callback.
 
 ```
 action(_:) ─▶ [Queue] ─▶ [Mutate] ─▶ [Effect] ─▶ [Reduce] ─▶ state
@@ -585,18 +587,16 @@ pile up behind a blocked main queue, and only queue latency shows that.
 Instrumentation is opt-in. Override `instrumentation` on the Reactable you care about:
 
 ```swift
-#if DEBUG
 extension MyHighFrequencyReactable {
-    var instrumentation: ReactableInstrument.Options? { .default }
+    var instrumentation: ReactableInstrument.Options<Action>? { .default }
 }
-#endif
 ```
 
 `Options` takes a `label` to tell several instances of the same type apart, and a
 `warningThreshold` to override the global one for this Reactable:
 
 ```swift
-var instrumentation: ReactableInstrument.Options? {
+var instrumentation: ReactableInstrument.Options<Action>? {
     .init(label: "carplay", warningThreshold: 0.016)   // one frame at 60fps
 }
 ```
@@ -664,6 +664,71 @@ default) / category `Reactable`.
 The sample app has a playground screen — `📈 ReactableInstrument Playground` in
 `Example/SampleProject` — with sliders for the threshold and the per-action cost, buttons that make
 each stage slow on purpose, and a burst/flood stress test that reproduces a main-queue backlog.
+
+## 📊 Target lifecycle events
+
+`ReactableInstrument.Target` observes selected stages for matching actions. Targets are generic and
+can be consumed by any release-safe metrics system through `onTargetEvent`.
+
+```swift
+var instrumentation: ReactableInstrument.Options<Action>? {
+    .init(targets: [
+        .init(
+            .init(rawValue: "guide-helper.update-location"),
+            observing: [.effect],
+            emittingIn: .all
+        ) { (action: Action) in
+            guard case .locationUpdated = action else { return false }
+            return true
+        }
+    ])
+}
+
+ReactableInstrument.onTargetEvent = { event in
+    // Dispatch blocking work to a consumer-owned queue.
+    print(event)
+}
+```
+
+`emittingIn` accepts `.debugOnly`, `.releaseOnly`, or `.all`. `mutate` measures the synchronous
+`mutate(action:)` call, `reduce` measures each synchronous `reduce(state:mutation:)` call, and
+`effect` measures the returned publisher from subscription to completion. `effect` includes
+synchronous reductions delivered before publisher completion and is suitable for one cycle-level
+metric. Selected stages for one action share a cycle ID; a publisher cancellation produces
+`cancelled` instead of `finished`.
+
+The default target list and target callback are both empty. When no target callback is installed,
+the target path returns before target allocation or timestamping. Target callbacks run on the
+stream's delivery thread and must return promptly.
+
+## ⏱️ Instrumentation cost
+
+Instrumentation is not free, and **DEBUG costs far more than release**. Measured by driving
+1,000,000 actions through a Reactable whose `mutate` and `reduce` do almost nothing, on an iOS
+simulator — the worst case, where nothing hides the overhead behind real work:
+
+| | DEBUG | Release |
+|---|---|---|
+| no instrumentation | 5.9 µs/action | 4.5 µs/action |
+| `instrumentation` set, no targets | 18.4 µs (×3.11) | 4.5 µs (×1.00) |
+| targets declared, no handler installed | 18.8 µs (×3.18) | 4.5 µs (×0.99) |
+| targets on all three stages, handler installed | 24.0 µs (×4.06) | 7.6 µs (×1.68) |
+
+Two things make DEBUG worse. It runs the signpost, statistics and warning code that a release build
+compiles out entirely, and that code is built `-Onone`: the *same* target path costs +3.1 µs in
+release and +5.6 µs in DEBUG.
+
+What follows from the numbers:
+
+- **Leaving targets declared is safe.** With no targets, or with targets but no `onTargetEvent`
+  installed, the cost is not measurable — the path returns before any allocation or timestamp.
+- **DEBUG instrumentation distorts what it measures.** Roughly 3× on a trivial cycle. Turning it on
+  for a high-frequency Reactable changes the very timings you are reading, so opt in per Reactable
+  rather than reaching for `enabledByDefault`.
+- `ReactableInstrument.statisticsEnabled = false` removes about 12% of the DEBUG overhead when the
+  aggregated report is not needed.
+- A `mutate`/`reduce` that does real work shrinks every ratio above, because the fixed per-stage cost
+  is then a smaller share of the cycle.
 
 ## 🏗️ Roadmap
 

--- a/README/README_ko.md
+++ b/README/README_ko.md
@@ -523,8 +523,8 @@ extension MyFactory: DependencyInjectable {
 ## 🔬 디버깅 — `ReactableInstrument`
 
 `ReactableInstrument`는 Reactable 사이클의 각 단계를 계측하고, 임계를 넘는 단계를 경고합니다.
-**DEBUG 빌드에서만** 존재하며, 계측 파일과 `Reactable` 내부 호출부 전체가 `#if DEBUG`로 제거되므로
-릴리즈 빌드에는 아무것도 남지 않습니다.
+DEBUG 빌드에서는 `os_signpost`와 경고 로그를 기록하고, 모든 빌드에서 선택한 단계의 생명주기 이벤트를
+대상 콜백으로 전달할 수 있습니다.
 
 ```
 action(_:) ─▶ [Queue] ─▶ [Mutate] ─▶ [Effect] ─▶ [Reduce] ─▶ state
@@ -545,18 +545,16 @@ UI 밀림을 볼 때는 `Queue`를 보세요. 각 단계는 멀쩡해 보이는�
 계측은 opt-in입니다. 필요한 Reactable에서 `instrumentation`을 재정의합니다.
 
 ```swift
-#if DEBUG
 extension MyHighFrequencyReactable {
-    var instrumentation: ReactableInstrument.Options? { .default }
+    var instrumentation: ReactableInstrument.Options<Action>? { .default }
 }
-#endif
 ```
 
 `Options`의 `label`로 같은 타입의 여러 인스턴스를 구분하고, `warningThreshold`로 이 Reactable만의
 임계를 지정할 수 있습니다.
 
 ```swift
-var instrumentation: ReactableInstrument.Options? {
+var instrumentation: ReactableInstrument.Options<Action>? {
     .init(label: "carplay", warningThreshold: 0.016)   // 60fps 기준 한 프레임
 }
 ```
@@ -587,6 +585,68 @@ Slow reduce: playground.MyReactable updateLocation took 200.3ms (threshold 50.0m
 `Effect`는 `reduce`보다 상류에서 측정되고, Combine은 값을 `reduce`까지 동기적으로 전달한 뒤에야 완료
 이벤트를 보냅니다. 따라서 느린 `reduce`는 `Effect` 샘플도 함께 늘립니다. `Slow effect`와
 `Slow reduce`가 같은 액션을 지목하면 원인은 reduce이며, effect가 비동기 작업을 하는 게 아닙니다.
+
+### 대상 생명주기 이벤트
+
+`ReactableInstrument.Target`은 일치하는 액션의 선택한 단계를 관찰합니다. 대상 ID와 콜백 소비자는
+라이브러리와 독립적이므로 Firebase Performance 같은 릴리즈 안전한 수집기에 연결할 수 있습니다.
+
+```swift
+var instrumentation: ReactableInstrument.Options<Action>? {
+    .init(targets: [
+        .init(
+            .init(rawValue: "guide-helper.update-location"),
+            observing: [.effect],
+            emittingIn: .all
+        ) { (action: Action) in
+            guard case .locationUpdated = action else { return false }
+            return true
+        }
+    ])
+}
+
+ReactableInstrument.onTargetEvent = { event in
+    // 소비자 소유 큐에서 오래 걸리는 작업을 처리합니다.
+    print(event)
+}
+```
+
+`emittingIn`은 `.debugOnly`, `.releaseOnly`, `.all` 중 하나입니다. `mutate`는 `mutate(action:)` 호출,
+`reduce`는 각 `reduce(state:mutation:)` 호출, `effect`는 퍼블리셔 구독부터 완료까지의 시간을 측정합니다.
+`effect`에는 완료 전에 동기적으로 처리된 reduce가 포함되므로 한 사이클 지표로 사용할 수 있습니다.
+한 액션의 대상 단계들은 사이클 ID를 공유하며, 퍼블리셔가 취소되면 `finished` 대신 `cancelled`가 전달됩니다.
+
+기본 대상 목록과 대상 콜백은 비어 있습니다. 대상 콜백이 설치되지 않으면 대상 경로는 대상 할당이나 타임스탬프
+측정 전에 종료됩니다. 대상 콜백은 스트림 전달 스레드에서 실행되므로 빠르게 반환해야 합니다.
+
+### 계측 비용
+
+계측에도 비용이 들고, **DEBUG가 릴리즈보다 훨씬 비쌉니다.** `mutate`와 `reduce`가 거의 아무 일도
+하지 않는 Reactable에 액션 1,000,000개를 흘려 iOS 시뮬레이터에서 잰 값입니다. 사이클이 하는 일이 없으니
+계측 비용이 그대로 드러나는, 가장 불리한 조건입니다.
+
+| | DEBUG | Release |
+|---|---|---|
+| 계측 없음 | 5.9 µs/action | 4.5 µs/action |
+| `instrumentation` 설정, 대상 없음 | 18.4 µs (×3.11) | 4.5 µs (×1.00) |
+| 대상 선언, 콜백 미설치 | 18.8 µs (×3.18) | 4.5 µs (×0.99) |
+| 세 단계 전부 관찰, 콜백 설치 | 24.0 µs (×4.06) | 7.6 µs (×1.68) |
+
+DEBUG가 비싼 이유는 두 가지입니다. 릴리즈에서는 아예 컴파일되지 않는 시그포스트·통계·경고 코드를
+DEBUG에서는 실제로 실행하고, 그 코드가 `-Onone`으로 빌드됩니다. 양쪽이 똑같은 코드인 대상 경로만 떼어
+보면 릴리즈에서 +3.1 µs, DEBUG에서 +5.6 µs가 듭니다.
+
+정리하면:
+
+- **대상을 선언해 둔 채로 출시해도 됩니다.** 대상이 없거나, 대상이 있어도 `onTargetEvent`를 설치하지
+  않았다면 비용이 측정에 잡히지 않습니다. 무언가를 할당하거나 시간을 재기 전에 빠져나옵니다.
+- **DEBUG 계측은 자기가 재려는 값을 바꿔놓습니다.** 빈 사이클 기준으로 약 3배입니다. 호출이 잦은
+  Reactable에 켜면 확인하려던 시간 자체가 달라지므로, `enabledByDefault`로 한 번에 켜지 말고 필요한
+  Reactable에만 켜세요.
+- 집계 리포트가 필요 없다면 `ReactableInstrument.statisticsEnabled = false`로 DEBUG 오버헤드를 약 12%
+  줄일 수 있습니다.
+- `mutate`와 `reduce`가 실제로 일을 하면 위 배수는 모두 작아집니다. 단계마다 붙는 고정 비용이 사이클
+  전체에서 차지하는 몫이 줄기 때문입니다.
 
 ### 집계 리포트
 

--- a/Sources/ReactableKit/Publisher+Extension.swift
+++ b/Sources/ReactableKit/Publisher+Extension.swift
@@ -208,7 +208,7 @@ public extension AnyPublisher where Output: Sendable, Failure == Never {
     /// - Returns: A publisher wrapping the given asynchronous work.
     static func run(
         priority: TaskPriority? = nil,
-        operation: @Sendable @escaping (_ send: Send<Output>) async throws -> Void,
+        operation: @MainActor @Sendable @escaping (_ send: Send<Output>) async throws -> Void,
         catch handler: (@Sendable (_ error: any Error, _ send: Send<Output>) async -> Void)? = nil
     ) -> AnyPublisher<Output, Never> {
         Deferred {

--- a/Sources/ReactableKit/Reactable.swift
+++ b/Sources/ReactableKit/Reactable.swift
@@ -5,6 +5,7 @@
 //  Created by Jeehoon Son on 1/23/25.
 //
 
+import Foundation
 import SwiftUI
 @_exported import Combine
 
@@ -30,6 +31,7 @@ public protocol Reactable: AnyObject, IdentityHashable {
     var currentState: State { get }
     var cancellables: Set<AnyCancellable> { get set }
     var resultSubject: PassthroughSubject<ObservableEventResult<Self>, Never> { get set }
+    var instrumentation: ReactableInstrument.Options<Action>? { get }
     
     func initialize()
     func action(_ action: Action)
@@ -37,17 +39,6 @@ public protocol Reactable: AnyObject, IdentityHashable {
     func reduce(state: inout State, mutation: Mutation)
     func transformAction() -> AnyPublisher<Action, Never>
 
-    #if DEBUG
-    /// Instrumentation configuration for this Reactable's cycle: `os_signpost` intervals for
-    /// queue latency, mutate, effect, and reduce, plus a warning whenever a stage exceeds its
-    /// threshold.
-    ///
-    /// Returns `nil` by default, which means this Reactable is not measured. Override it to opt
-    /// in — global switches (`ReactableInstrument.enabledByDefault`, `filter`, or the
-    /// `REACTABLE_INSTRUMENT` environment variable) can still enable it without an override.
-    /// Removed entirely from release builds.
-    var instrumentation: ReactableInstrument.Options? { get }
-    #endif
 }
 
 public extension Reactable {
@@ -78,9 +69,7 @@ public extension Reactable {
         Empty<Mutation, Never>().eraseToAnyPublisher()
     }
     
-    #if DEBUG
-    var instrumentation: ReactableInstrument.Options? { nil }
-    #endif
+    var instrumentation: ReactableInstrument.Options<Action>? { nil }
     
     func reduce(state: inout State, mutation: Mutation) { }
     
@@ -150,11 +139,42 @@ public extension Reactable {
         let stream = Stream(action: actionSubject, state: stateSubject)
         WeakCache.stream.setValue(stream, forKey: self)
 
-        #if DEBUG
         // Resolved once per stream rather than once per action: building this string on every
         // cycle would be exactly the kind of hidden cost the instrument exists to catch.
         let instrumentName = String(describing: type(of: self))
-        #endif
+        let activeTargets = self.instrumentation?.targets.filter { $0.emitsInCurrentBuild && !$0.stages.isEmpty } ?? []
+        let targetEventHandler = ReactableInstrument.targetEventHandler()
+
+        @inline(__always)
+        func measureTargets<Output>(
+            _ stage: ReactableInstrument.Stage,
+            cycles: [ReactableTargetCycle<Action>],
+            _ operation: () -> Output
+        ) -> Output {
+            guard !cycles.isEmpty else { return operation() }
+            let measurements = cycles.compactMap { $0.begin(stage) }
+            let output = operation()
+            let endedAt = ReactableInstrument.timestamp()
+            measurements.forEach { $0.finish(at: endedAt) }
+            return output
+        }
+
+        @inline(__always)
+        func measureTargetEffect(
+            _ publisher: AnyPublisher<Mutation, Never>,
+            cycles: [ReactableTargetCycle<Action>]
+        ) -> AnyPublisher<Mutation, Never> {
+            guard cycles.contains(where: { $0.target.stages.contains(.effect) }) else { return publisher }
+
+            let measurement = TargetEffectMeasurement(cycles: cycles)
+            return publisher
+                .handleEvents(
+                    receiveSubscription: { _ in measurement.start() },
+                    receiveCompletion: { _ in measurement.finish() },
+                    receiveCancel: measurement.cancel
+                )
+                .eraseToAnyPublisher()
+        }
 
         let transformedActionStream = self.transformAction()
             .eraseToAnyPublisher()
@@ -170,14 +190,23 @@ public extension Reactable {
             .flatMap { [weak self] identity -> AnyPublisher<(IdentityAction, Mutation), Never> in
                 guard let self = self else { return .empty() }
 
-                let mutationPublisher: AnyPublisher<Mutation, Never>
-                #if DEBUG
                 var identity = identity
                 // `isStub` is read per action rather than once per stream: a Reactable can be
                 // wrapped in a `Stub` after its stream already exists, and `Stub` drives
                 // `mutate`/`reduce` directly *and* through the stream, so measuring it would count
-                // every sample twice. Checked after `resolveOptions` so a Reactable nobody asked to
-                // measure never pays for the lookup.
+                // every sample twice.
+                if !activeTargets.isEmpty, !self.isStub, let receive = targetEventHandler {
+                    identity.targetCycles = ReactableTargetCycle.make(
+                        for: identity.action,
+                        targets: activeTargets,
+                        reactable: instrumentName,
+                        receive: receive
+                    )
+                }
+                let targetCycles = identity.targetCycles
+
+                let mutationPublisher: AnyPublisher<Mutation, Never>
+                #if DEBUG
                 if let options = ReactableInstrument.resolveOptions(
                        name: instrumentName,
                        instrumentation: self.instrumentation
@@ -203,20 +232,20 @@ public extension Reactable {
                             reactable: instrumentName,
                             action: actionName
                         ) {
-                            self.mutate(action: identity.action)
+                            measureTargets(.mutate, cycles: targetCycles) { self.mutate(action: identity.action) }
                         },
                         options: options,
                         reactable: instrumentName,
                         action: actionName
                     )
                 } else {
-                    mutationPublisher = self.mutate(action: identity.action)
+                    mutationPublisher = measureTargets(.mutate, cycles: targetCycles) { self.mutate(action: identity.action) }
                 }
                 #else
-                mutationPublisher = self.mutate(action: identity.action)
+                mutationPublisher = measureTargets(.mutate, cycles: targetCycles) { self.mutate(action: identity.action) }
                 #endif
 
-                return mutationPublisher
+                return measureTargetEffect(mutationPublisher, cycles: targetCycles)
                     .map { (identity, $0) }
                     .handleEvents(receiveCompletion: { [weak self] completion in
                         guard let self else { return }
@@ -243,13 +272,13 @@ public extension Reactable {
                         reactable: instrumentName,
                         mutation: .caseName(of: mutation)
                     ) {
-                        self.reduce(state: &newState, mutation: mutation)
+                        measureTargets(.reduce, cycles: action.targetCycles) { self.reduce(state: &newState, mutation: mutation) }
                     }
                 } else {
-                    self.reduce(state: &newState, mutation: mutation)
+                    measureTargets(.reduce, cycles: action.targetCycles) { self.reduce(state: &newState, mutation: mutation) }
                 }
                 #else
-                self.reduce(state: &newState, mutation: mutation)
+                measureTargets(.reduce, cycles: action.targetCycles) { self.reduce(state: &newState, mutation: mutation) }
                 #endif
                 return (action, newState)
             }
@@ -277,6 +306,146 @@ public extension Reactable {
     }
 }
 
+// MARK: - Target instrumentation
+
+/// `cycle` ties one action's mutate, effect and reduce measurements together for one target.
+struct ReactableTargetCycle<Action: Sendable>: Sendable {
+    let target: ReactableInstrument.Target<Action>
+    let cycle: UInt64
+    let reactable: String
+    let receive: @Sendable (ReactableInstrument.TargetEvent) -> Void
+
+    @inline(__always)
+    static func make(
+        for action: Action,
+        targets: [ReactableInstrument.Target<Action>],
+        reactable: String,
+        receive: @escaping @Sendable (ReactableInstrument.TargetEvent) -> Void
+    ) -> [ReactableTargetCycle] {
+        targets.compactMap { target in
+            guard target.includes(action) else { return nil }
+            return ReactableTargetCycle(
+                target: target,
+                cycle: ReactableInstrument.makeTargetCycle(),
+                reactable: reactable,
+                receive: receive
+            )
+        }
+    }
+
+    @inline(__always)
+    func begin(_ stage: ReactableInstrument.Stage) -> TargetStageMeasurement<Action>? {
+        guard self.target.stages.contains(stage) else { return nil }
+        let id = ReactableInstrument.MeasurementID(
+            target: self.target.id,
+            cycle: self.cycle,
+            stage: stage,
+            occurrence: ReactableInstrument.makeTargetOccurrence()
+        )
+        let context = ReactableInstrument.TargetEventContext(id: id, reactable: self.reactable)
+        self.receive(.started(context))
+        return TargetStageMeasurement(
+            cycle: self,
+            context: context,
+            startedAt: ReactableInstrument.timestamp()
+        )
+    }
+}
+
+struct TargetStageMeasurement<Action: Sendable>: Sendable {
+    let cycle: ReactableTargetCycle<Action>
+    let context: ReactableInstrument.TargetEventContext
+    let startedAt: UInt64
+
+    @inline(__always)
+    func finish(at endedAt: UInt64, cancelled: Bool = false) {
+        let duration = ReactableInstrument.duration(from: self.startedAt, to: endedAt)
+        self.cycle.receive(
+            cancelled
+                ? .cancelled(self.context, duration: duration)
+                : .finished(self.context, duration: duration)
+        )
+    }
+}
+
+/// Orders the effect stage's events. A publisher can complete or be cancelled from inside
+/// `receiveSubscription`, so a terminal reached before the `started` events are emitted is held
+/// until they are, keeping every `started` paired with exactly one terminal event.
+private final class TargetEffectMeasurement<Action: Sendable>: @unchecked Sendable {
+    private enum State {
+        case idle
+        case starting
+        case started([TargetStageMeasurement<Action>])
+        case terminalBeforeStart(cancelled: Bool, endedAt: UInt64)
+        case terminalEmitted
+    }
+
+    private let cycles: [ReactableTargetCycle<Action>]
+    private let lock = NSLock()
+    private var state: State = .idle
+
+    init(cycles: [ReactableTargetCycle<Action>]) {
+        self.cycles = cycles
+    }
+
+    func start() {
+        self.lock.lock()
+        guard case .idle = self.state else {
+            self.lock.unlock()
+            return
+        }
+        self.state = .starting
+        self.lock.unlock()
+
+        let measurements = self.cycles.compactMap { $0.begin(.effect) }
+        var terminal: (cancelled: Bool, endedAt: UInt64)?
+        self.lock.lock()
+        switch self.state {
+        case .starting:
+            self.state = .started(measurements)
+        case let .terminalBeforeStart(cancelled, endedAt):
+            self.state = .terminalEmitted
+            terminal = (cancelled, endedAt)
+        case .idle, .started(_), .terminalEmitted:
+            break
+        }
+        self.lock.unlock()
+
+        if let terminal {
+            measurements.forEach {
+                $0.finish(at: terminal.endedAt, cancelled: terminal.cancelled)
+            }
+        }
+    }
+
+    func finish() {
+        self.end(cancelled: false)
+    }
+
+    func cancel() {
+        self.end(cancelled: true)
+    }
+
+    private func end(cancelled: Bool) {
+        let endedAt = ReactableInstrument.timestamp()
+        var measurements: [TargetStageMeasurement<Action>]?
+
+        self.lock.lock()
+        switch self.state {
+        case .idle, .terminalEmitted, .terminalBeforeStart(_, _):
+            break
+        case .starting:
+            self.state = .terminalBeforeStart(cancelled: cancelled, endedAt: endedAt)
+        case let .started(value):
+            self.state = .terminalEmitted
+            measurements = value
+        }
+        self.lock.unlock()
+
+        measurements?.forEach { $0.finish(at: endedAt, cancelled: cancelled) }
+    }
+}
+
 struct Stream<A: Sendable, S: Sendable>: Sendable {
     var action: PassthroughSubject<A, Never>
     var state: ReplaySubject<S, Never>
@@ -285,13 +454,14 @@ struct Stream<A: Sendable, S: Sendable>: Sendable {
 struct Identity<R: Reactable, A: Sendable>: Sendable {
     var action: A
     var continuation: CheckedContinuation<R.State, Never>?
+    var targetCycles: [ReactableTargetCycle<A>] = []
     #if DEBUG
     /// Monotonic timestamp taken when the action was handed to the main queue, used to measure
     /// how long it waited before `mutate` ran. Release builds do not carry this.
     var enqueuedAt: UInt64?
     /// Instrument options resolved once in the mutate stage and reused by reduce, so the
     /// process-wide instrument lock is taken once per action rather than once per mutation.
-    var instrumentOptions: ReactableInstrument.Options?
+    var instrumentOptions: ReactableInstrument.Options<A>?
     #endif
 
     /// Builds an identity, stamping the enqueue time in DEBUG builds.

--- a/Sources/ReactableKit/ReactableInstrument.swift
+++ b/Sources/ReactableKit/ReactableInstrument.swift
@@ -2,7 +2,7 @@
 //  ReactableInstrument.swift
 //  ReactableKit
 //
-//  DEBUG-only instrumentation for the Reactable cycle.
+//  Reactable cycle instrumentation.
 //
 //  Every stage of the cycle is reported as an `os_signpost` interval so it shows up on the
 //  Instruments timeline, and anything slower than a threshold is logged as a warning:
@@ -16,53 +16,183 @@
 //  - `Effect` the lifetime of that publisher, from subscription to completion.
 //  - `Reduce` the synchronous cost of applying a mutation to the state.
 //
-//  Instrumentation is opt-in. A Reactable turns it on by overriding `instrumentation`, or it can
-//  be enabled process-wide with `enabledByDefault`, `filter`, or the `REACTABLE_INSTRUMENT`
-//  environment variable. Nothing here exists in a release build — this file and every call site
-//  in `Reactable.swift` are removed by `#if DEBUG`.
+//  Signposts, statistics, and warnings are available only in DEBUG builds. Target lifecycle
+//  events are available in all builds and are opt-in through `instrumentation` and `onTargetEvent`.
 //
 //  Instruments recipe: Edit Scheme ▸ Profile ▸ Build Configuration = Debug, then ⌘I, add the
 //  "os_signpost" instrument and look for subsystem `ReactableInstrument.subsystem`,
 //  category `Reactable`.
 //
 
+import Foundation
+
 #if DEBUG
 import Combine
-import Foundation
 import os
+#endif
 
 public enum ReactableInstrument {
 
     // MARK: - Options
 
-    /// Per-Reactable instrumentation configuration. Return one from `Reactable.instrumentation`
-    /// to turn measurement on for that Reactable.
-    public struct Options: Sendable {
-        /// Prefix used to tell several instances of the same type apart (for example "carplay").
-        /// Rendered ahead of the type name in signposts and warnings.
+    public struct Options<Action: Sendable>: Sendable {
         public var label: String?
-
-        /// Warning threshold for this Reactable only. `nil` falls back to
-        /// `ReactableInstrument.warningThreshold`.
         public var warningThreshold: TimeInterval?
+        public var targets: [Target<Action>]
 
-        public static let `default` = Options()
+        public static var `default`: Self { .init() }
 
-        public init(label: String? = nil, warningThreshold: TimeInterval? = nil) {
+        public init(
+            label: String? = nil,
+            warningThreshold: TimeInterval? = nil,
+            targets: [Target<Action>] = []
+        ) {
             self.label = label
             self.warningThreshold = warningThreshold
+            self.targets = targets
         }
     }
 
-    // MARK: - Events
-
-    /// A stage of the Reactable cycle.
-    public enum Stage: String, Sendable, CaseIterable {
+    public enum Stage: String, Hashable, Sendable, CaseIterable {
         case queue
         case mutate
         case effect
         case reduce
     }
+
+    public struct TargetID: Hashable, Sendable, RawRepresentable {
+        public let rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+    }
+
+    public struct Target<Action: Sendable>: Sendable {
+        /// Build configurations in which the target callback receives lifecycle events.
+        public enum BuildConfiguration: Hashable, Sendable {
+            case debugOnly
+            case releaseOnly
+            case all
+        }
+
+        public let id: TargetID
+        public let stages: Set<Stage>
+        public let buildConfiguration: BuildConfiguration
+        private let includesAction: @Sendable (Action) -> Bool
+
+        public init(
+            _ id: TargetID,
+            observing stages: Set<Stage>,
+            emittingIn buildConfiguration: BuildConfiguration = .debugOnly,
+            _ includes: @escaping @Sendable (Action) -> Bool = { _ in true }
+        ) {
+            self.id = id
+            self.stages = stages
+            self.buildConfiguration = buildConfiguration
+            self.includesAction = includes
+        }
+
+        internal func includes(_ action: Action) -> Bool {
+            self.includesAction(action)
+        }
+
+        internal var emitsInCurrentBuild: Bool {
+            #if DEBUG
+            self.buildConfiguration != .releaseOnly
+            #else
+            self.buildConfiguration != .debugOnly
+            #endif
+        }
+    }
+
+    public struct MeasurementID: Hashable, Sendable {
+        public let target: TargetID
+        public let cycle: UInt64
+        public let stage: Stage
+        public let occurrence: UInt64
+
+        public init(
+            target: TargetID,
+            cycle: UInt64,
+            stage: Stage,
+            occurrence: UInt64 = 0
+        ) {
+            self.target = target
+            self.cycle = cycle
+            self.stage = stage
+            self.occurrence = occurrence
+        }
+    }
+
+    public struct TargetEventContext: Sendable {
+        public let id: MeasurementID
+        public let reactable: String
+
+        public init(id: MeasurementID, reactable: String) {
+            self.id = id
+            self.reactable = reactable
+        }
+    }
+
+    public enum TargetEvent: Sendable {
+        case started(TargetEventContext)
+        case finished(TargetEventContext, duration: TimeInterval)
+        case cancelled(TargetEventContext, duration: TimeInterval)
+    }
+
+    private static let targetEventLock = NSLock()
+    private nonisolated(unsafe) static var _onTargetEvent: (@Sendable (TargetEvent) -> Void)?
+    private nonisolated(unsafe) static var nextTargetCycle: UInt64 = 0
+    private nonisolated(unsafe) static var nextTargetOccurrence: UInt64 = 0
+
+    /// Receives selected target lifecycle events. Install the callback before a Reactable stream is created.
+    public static var onTargetEvent: (@Sendable (TargetEvent) -> Void)? {
+        get { self.targetEventLock.perform { self._onTargetEvent } }
+        set { self.targetEventLock.perform { self._onTargetEvent = newValue } }
+    }
+
+    internal static func makeTargetCycle() -> UInt64 {
+        self.targetEventLock.perform {
+            self.nextTargetCycle &+= 1
+            return self.nextTargetCycle
+        }
+    }
+
+    internal static func makeTargetOccurrence() -> UInt64 {
+        self.targetEventLock.perform {
+            self.nextTargetOccurrence &+= 1
+            return self.nextTargetOccurrence
+        }
+    }
+
+    internal static func targetEventHandler() -> (@Sendable (TargetEvent) -> Void)? {
+        self.targetEventLock.perform { self._onTargetEvent }
+    }
+
+    // MARK: - Timing
+
+    /// Monotonic timestamp in nanoseconds. Not affected by wall-clock adjustments, unlike `Date`.
+    @inline(__always)
+    public static func timestamp() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    @inline(__always)
+    public static func elapsed(since start: UInt64) -> TimeInterval {
+        self.duration(from: start, to: self.timestamp())
+    }
+
+    /// Interval between two `timestamp()` readings. Used when several measurements share a single
+    /// end reading, so they all report against the same instant.
+    @inline(__always)
+    internal static func duration(from start: UInt64, to end: UInt64) -> TimeInterval {
+        guard end > start else { return 0 }
+        return TimeInterval(end - start) / 1_000_000_000
+    }
+
+    #if DEBUG
+    // MARK: - Events
 
     /// A single measurement. Delivered to `onEvent` regardless of whether it exceeded the
     /// threshold, so a debug tool can render every cycle rather than only the slow ones.
@@ -252,36 +382,24 @@ public enum ReactableInstrument {
     /// it decides on its own — a non-matching type name is *not* instrumented even when
     /// `enabledByDefault` or `REACTABLE_INSTRUMENT` is on, so a filter narrows a global switch
     /// rather than widening it.
-    public static func resolveOptions(name: String, instrumentation: Options?) -> Options? {
+    public static func resolveOptions<Action: Sendable>(
+        name: String,
+        instrumentation: Options<Action>?
+    ) -> Options<Action>? {
         if let instrumentation { return instrumentation }
         guard self.globalEnablementConfigured || self.environmentEnabled else { return nil }
-        return self.lock.perform { () -> Options? in
-            if let filter = self._filter { return filter(name) ? Options.default : nil }
-            if self._enabledByDefault || self.environmentEnabled { return Options.default }
+        return self.lock.perform { () -> Options<Action>? in
+            if let filter = self._filter { return filter(name) ? .default : nil }
+            if self._enabledByDefault || self.environmentEnabled { return .default }
             return nil
         }
-    }
-
-    // MARK: - Timing
-
-    /// Monotonic timestamp in nanoseconds. Not affected by wall-clock adjustments, unlike `Date`.
-    @inline(__always)
-    public static func timestamp() -> UInt64 {
-        DispatchTime.now().uptimeNanoseconds
-    }
-
-    @inline(__always)
-    public static func elapsed(since start: UInt64) -> TimeInterval {
-        let now = DispatchTime.now().uptimeNanoseconds
-        guard now > start else { return 0 }
-        return TimeInterval(now - start) / 1_000_000_000
     }
 
     // MARK: - Measurement
 
     /// Measures the synchronous cost of building a mutation publisher.
-    public static func measureMutate<Result>(
-        options: Options = .default,
+    public static func measureMutate<Action: Sendable, Result>(
+        options: Options<Action>,
         reactable: String,
         action: LazyName,
         _ body: () -> Result
@@ -290,8 +408,8 @@ public enum ReactableInstrument {
     }
 
     /// Measures the synchronous cost of applying a mutation to the state.
-    public static func measureReduce(
-        options: Options = .default,
+    public static func measureReduce<Action: Sendable>(
+        options: Options<Action>,
         reactable: String,
         mutation: LazyName,
         _ body: () -> Void
@@ -303,8 +421,8 @@ public enum ReactableInstrument {
     ///
     /// This is the measurement that catches a backed-up main queue: every individual stage can look
     /// healthy while this number grows without bound.
-    public static func recordQueueLatency(
-        options: Options = .default,
+    public static func recordQueueLatency<Action: Sendable>(
+        options: Options<Action>,
         reactable: String,
         action: LazyName,
         enqueuedAt: UInt64
@@ -335,9 +453,9 @@ public enum ReactableInstrument {
     ///   `reduce` therefore inflates the `Effect` sample too, producing a second warning for the
     ///   same root cause. When `Slow effect` and `Slow reduce` report the same action, the reduce
     ///   is the cause — the effect is not doing async work.
-    public static func measureEffect<Output, Failure: Error>(
+    public static func measureEffect<Action: Sendable, Output, Failure: Error>(
         _ publisher: AnyPublisher<Output, Failure>,
-        options: Options = .default,
+        options: Options<Action>,
         reactable: String,
         action: LazyName
     ) -> AnyPublisher<Output, Failure> {
@@ -373,11 +491,11 @@ public enum ReactableInstrument {
             .eraseToAnyPublisher()
     }
 
-    private static func endEffect(
+    private static func endEffect<Action: Sendable>(
         _ tracker: EffectTracker,
         signposter: OSSignposter,
         cancelled: Bool,
-        options: Options,
+        options: Options<Action>,
         reactable: String,
         action: LazyName
     ) {
@@ -398,9 +516,9 @@ public enum ReactableInstrument {
         )
     }
 
-    private static func measure<Result>(
+    private static func measure<Action: Sendable, Result>(
         stage: Stage,
-        options: Options,
+        options: Options<Action>,
         reactable: String,
         name: LazyName,
         _ body: () -> Result
@@ -428,9 +546,9 @@ public enum ReactableInstrument {
     ///
     /// The case name is only materialised if something actually needs it, so a Reactable measured
     /// with statistics off and no observer attached pays no reflection cost on a fast cycle.
-    private static func finish(
+    private static func finish<Action: Sendable>(
         stage: Stage,
-        options: Options,
+        options: Options<Action>,
         reactable: String,
         name: LazyName,
         duration: TimeInterval
@@ -707,7 +825,11 @@ public enum ReactableInstrument {
 
     // MARK: - Formatting
 
-    private static func subjectText(options: Options, reactable: String, name: String) -> String {
+    private static func subjectText<Action: Sendable>(
+        options: Options<Action>,
+        reactable: String,
+        name: String
+    ) -> String {
         guard let label = options.label else { return "\(reactable) \(name)" }
         return "\(label).\(reactable) \(name)"
     }
@@ -753,8 +875,10 @@ public enum ReactableInstrument {
             }
         }
     }
+    #endif
 }
 
+#if DEBUG
 private extension ReactableInstrument.Stage {
     var signpostName: StaticString {
         switch self {


### PR DESCRIPTION
## Summary

`ReactableInstrument` measures the Reactable cycle, but everything it produces is `#if DEBUG` — a
shipped app can't see its own timings. This PR adds **targets**: a Reactable declares which cycle
stages it wants reported, for which actions, and in which build configurations; the app installs one
`ReactableInstrument.onTargetEvent` handler and forwards the events wherever it likes (Firebase
Performance, a custom collector, an internal debug menu).

The existing signpost / statistics / warning behaviour is unchanged and still DEBUG-only.

## Motivation

The signpost instrumentation answers "why is this slow on my machine, right now". It cannot answer
"which cycle is slow on real devices, in the field" — the code that would tell you is compiled out
of the build users actually run. Targets fill that gap without turning the whole instrument on in
release: they are opt-in per Reactable, per action, and per stage.

## What's in here

**`feat: emit target lifecycle events in every build`**

- `ReactableInstrument.Target` — a `TargetID`, the set of `Stage`s to observe, a `BuildConfiguration`
  (`.debugOnly` / `.releaseOnly` / `.all`), and an action predicate.
- `ReactableInstrument.onTargetEvent` — one process-wide handler receiving
  `started` / `finished(duration:)` / `cancelled(duration:)`.
- Every event carries a `MeasurementID` whose `cycle` ties one action's `mutate`, `effect` and
  `reduce` measurements together, so a consumer can reassemble a whole cycle. Each `started` is
  paired with exactly one terminal event, including when a publisher is cancelled or completes from
  inside `receiveSubscription`.
- `Options` becomes generic over `Action` so the predicate can pattern-match the action.
- The timing helpers move out of `#if DEBUG` (release needs them now) and gain
  `duration(from:to:)` for measurements that share a single end reading.
- The cycle instrumentation is inline in `createStream`, so the measured and unmeasured paths stay
  readable side by side in one diff.

**`docs: document target events and what instrumentation costs`** — both READMEs.

**`fix: preserve main actor context for run operations`** — pre-existing commit on this branch:
`AnyPublisher.run(priority:operation:catch:)`'s `operation` gains `@MainActor`, so work started from
a `mutate` stays on the main actor instead of hopping off it.

## Cost

Measured by driving 1,000,000 actions through a Reactable whose `mutate` and `reduce` do almost
nothing, on an iOS simulator — the worst case, where nothing hides the overhead behind real work:

| | DEBUG | Release |
|---|---|---|
| no instrumentation | 5.9 µs/action | 4.5 µs/action |
| `instrumentation` set, no targets | 18.4 µs (×3.11) | 4.5 µs (×1.00) |
| targets declared, no handler installed | 18.8 µs (×3.18) | 4.5 µs (×0.99) |
| targets on all three stages, handler installed | 24.0 µs (×4.06) | 7.6 µs (×1.68) |

A release build pays nothing measurable until a handler is actually installed — with no targets, or
targets but no handler, the path returns before any allocation or timestamp. The DEBUG column is
higher both because it runs the signpost/statistics/warning code that release compiles out, and
because that code is built `-Onone`: the *same* target path costs +3.1 µs in release and +5.6 µs in
DEBUG. The READMEs carry this table, since DEBUG instrumentation is heavy enough to distort the
timings it reports.

## Compatibility

Source-breaking for DEBUG-only code that declared instrumentation:

```swift
// before
var instrumentation: ReactableInstrument.Options? { .default }
// after
var instrumentation: ReactableInstrument.Options<Action>? { .default }
```

`ReactableInstrument` was entirely `#if DEBUG` before this change, so no release code could reference
the type and nothing else is affected. The `instrumentation` requirement now exists in both
configurations and keeps its `nil` default, so conformers that never declared it are untouched, and
an existing `#if DEBUG`-wrapped override can drop the guard.

## Testing

Verified on an iOS 26 simulator in both build configurations:

- Existing suites pass in DEBUG (78 tests) and Release (60 tests).
- Two pre-existing Release failures in `WeakKeyDictionaryTests` (`testThreadSafetySequential`,
  `testDictionaryDeallocation`) reproduce on `main` — they are optimiser-dependent weak-reference
  assertions, unrelated to this change, and surface only because the suite had never been run in
  Release.
- `ViewStateTests` / `SharedViewStateTests` / `ReactableTests.testPublisher` are flaky
  `Task.sleep`-based timing tests that also fail intermittently on `main`.

The test cases covering the target events (stage pairing, shared cycle id, action filtering, build
configuration gating, stub exclusion, cancellation) and the load test that produced the table above
are not part of this branch; happy to push them here if you'd like them in the same PR.
